### PR TITLE
Allow a custom refreshToken callback in the Token constructor

### DIFF
--- a/src/token/token.js
+++ b/src/token/token.js
@@ -51,11 +51,12 @@ class Token {
 		 * Base refreshing function.
 		 *
 		 * @private
+		 * @member {String|Function} #_refresh
 		 */
-		this._refresh = () => defaultRefreshToken( tokenUrlOrRefreshToken );
-
 		if ( typeof tokenUrlOrRefreshToken === 'function' ) {
 			this._refresh = tokenUrlOrRefreshToken;
+		} else {
+			this._refresh = () => defaultRefreshToken( tokenUrlOrRefreshToken );
 		}
 
 		/**

--- a/src/token/token.js
+++ b/src/token/token.js
@@ -47,23 +47,16 @@ class Token {
 		 */
 		this.set( 'value', options.initValue );
 
-		let refresh = () => defaultRefreshToken( tokenUrlOrRefreshToken );
+		/**
+		 * Base refreshing function.
+		 *
+		 * @private
+		 */
+		this._refresh = () => defaultRefreshToken( tokenUrlOrRefreshToken );
 
 		if ( typeof tokenUrlOrRefreshToken === 'function' ) {
-			refresh = tokenUrlOrRefreshToken;
+			this._refresh = tokenUrlOrRefreshToken;
 		}
-
-		/**
-		 * Refresh token function.
-		 *
-		 * @member {Function} #_refreshToken
-		 * @protected
-		 */
-		this._refreshToken = () => {
-			return refresh()
-				.then( value => this.set( 'value', value ) )
-				.then( () => this );
-		};
 
 		/**
 		 * @type {Object}
@@ -93,6 +86,17 @@ class Token {
 
 			resolve( this );
 		} );
+	}
+
+	/**
+	 * Refresh token method. Useful in a method form as it can be override in tests.
+	 *
+	 * @protected
+	 */
+	_refreshToken() {
+		return this._refresh()
+				.then( value => this.set( 'value', value ) )
+				.then( () => this );
 	}
 
 	/**

--- a/src/token/token.js
+++ b/src/token/token.js
@@ -23,16 +23,16 @@ class Token {
 	 * Creates `Token` instance.
 	 * Method `init` should be called after using the constructor or use `create` method instead.
 	 *
-	 * @param {String|Function} tokenUrlOrTokenRefresh Endpoint address to download the token or a callback that provides the token. If the
+	 * @param {String|Function} tokenUrlOrRefreshToken Endpoint address to download the token or a callback that provides the token. If the
 	 * value is a function it has to match the {@link ~refreshToken} interface.
 	 * @param {Object} options
 	 * @param {String} [options.initValue] Initial value of the token.
 	 * @param {Number} [options.refreshInterval=3600000] Delay between refreshes. Default 1 hour.
 	 * @param {Boolean} [options.autoRefresh=true] Specifies whether to start the refresh automatically.
 	 */
-	constructor( tokenUrlOrTokenRefresh, options = DEFAULT_OPTIONS ) {
-		if ( !tokenUrlOrTokenRefresh ) {
-			throw new Error( 'A `tokenUrl` or a `tokenRefresh` function must be provided as the first constructor argument.' );
+	constructor( tokenUrlOrRefreshToken, options = DEFAULT_OPTIONS ) {
+		if ( !tokenUrlOrRefreshToken ) {
+			throw new Error( 'A `tokenUrl` or a `refreshToken` function must be provided as the first constructor argument.' );
 		}
 
 		/**
@@ -53,9 +53,9 @@ class Token {
 		 * @member {Function} #_refreshToken
 		 * @protected
 		 */
-		if ( typeof tokenUrlOrTokenRefresh === 'function' ) {
+		if ( typeof tokenUrlOrRefreshToken === 'function' ) {
 			this._refreshToken = () => {
-				return tokenUrlOrTokenRefresh()
+				return tokenUrlOrRefreshToken()
 					.then( value => this.set( 'value', value ) )
 					.then( () => this );
 			};
@@ -70,7 +70,7 @@ class Token {
 		 * @type {String}
 		 * @private
 		 */
-		this._tokenUrl = typeof tokenUrlOrTokenRefresh === 'string' ? tokenUrlOrTokenRefresh : '';
+		this._tokenUrl = typeof tokenUrlOrRefreshToken === 'string' ? tokenUrlOrRefreshToken : '';
 
 		/**
 		 * @type {Object}
@@ -155,7 +155,7 @@ class Token {
 	/**
 	 * Creates a initialized {@link Token} instance.
 	 *
-	 * @param {String|Function} tokenUrlOrTokenRefresh Endpoint address to download the token or a callback that provides the token. If the
+	 * @param {String|Function} tokenUrlOrRefreshToken Endpoint address to download the token or a callback that provides the token. If the
 	 * value is a function it has to match the {@link ~refreshToken} interface.
 	 * @param {Object} options
 	 * @param {String} [options.initValue] Initial value of the token.
@@ -163,8 +163,8 @@ class Token {
 	 * @param {Boolean} [options.autoRefresh=true] Specifies whether to start the refresh automatically.
 	 * @returns {Promise.<Token>}
 	 */
-	static create( tokenUrlOrTokenRefresh, options = DEFAULT_OPTIONS ) {
-		const token = new Token( tokenUrlOrTokenRefresh, options );
+	static create( tokenUrlOrRefreshToken, options = DEFAULT_OPTIONS ) {
+		const token = new Token( tokenUrlOrRefreshToken, options );
 
 		return token.init();
 	}

--- a/src/token/token.js
+++ b/src/token/token.js
@@ -135,7 +135,7 @@ mix( Token, ObservableMixin );
 
 /**
  * This function is called in a defined interval by the {@link ~Token} class.
- * It should return a promise, which resolves with the new token url.
+ * It should return a promise, which resolves with the new token value.
  * If any error occurs it should return a rejected promise with an error message.
  *
  * @function refreshToken

--- a/tests/token/token.js
+++ b/tests/token/token.js
@@ -27,7 +27,7 @@ describe( 'Token', () => {
 	describe( 'constructor()', () => {
 		it( 'should throw error when no tokenUrl provided', () => {
 			expect( () => new Token() ).to.throw(
-				'A `tokenUrl` or a `tokenRefresh` function must be provided as the first constructor argument.'
+				'A `tokenUrl` must be provided as the first constructor argument.'
 			);
 		} );
 


### PR DESCRIPTION
Feature: Allowed custom `refreshToken` callback in the `Token` constructor. Closes #16.