### PR TITLE
Expose the refreshToken method.

### DIFF
--- a/src/token/token.js
+++ b/src/token/token.js
@@ -89,7 +89,7 @@ class Token {
 			}
 
 			if ( !this.value ) {
-				this._refreshToken()
+				this.refreshToken()
 					.then( resolve )
 					.catch( reject );
 
@@ -102,10 +102,9 @@ class Token {
 
 	/**
 	 * Refresh token method. Useful in a method form as it can be override in tests.
-	 *
-	 * @protected
+	 * @returns {Promise.<String>}
 	 */
-	_refreshToken() {
+	refreshToken() {
 		return this._refresh()
 			.then( value => this.set( 'value', value ) )
 			.then( () => this );
@@ -124,7 +123,7 @@ class Token {
 	 * @protected
 	 */
 	_startRefreshing() {
-		this._refreshInterval = setInterval( () => this._refreshToken(), this._options.refreshInterval );
+		this._refreshInterval = setInterval( () => this.refreshToken(), this._options.refreshInterval );
 	}
 
 	/**
@@ -157,7 +156,7 @@ class Token {
 mix( Token, ObservableMixin );
 
 /**
- * This function is called in a defined interval by the {@link ~Token} class.
+ * This function is called in a defined interval by the {@link ~Token} class. It also can be invoked manually.
  * It should return a promise, which resolves with the new token value.
  * If any error occurs it should return a rejected promise with an error message.
  *

--- a/tests/token/token.js
+++ b/tests/token/token.js
@@ -129,11 +129,11 @@ describe( 'Token', () => {
 		} );
 	} );
 
-	describe( '_refreshToken()', () => {
+	describe( 'refreshToken()', () => {
 		it( 'should get a token from the specified address', done => {
 			const token = new Token( 'http://token-endpoint', { initValue: 'initValue', autoRefresh: false } );
 
-			token._refreshToken()
+			token.refreshToken()
 				.then( newToken => {
 					expect( newToken.value ).to.equal( 'token-value' );
 
@@ -146,7 +146,7 @@ describe( 'Token', () => {
 		it( 'should get a token from the specified callback function', () => {
 			const token = new Token( () => Promise.resolve( 'token-value' ), { initValue: 'initValue', autoRefresh: false } );
 
-			return token._refreshToken()
+			return token.refreshToken()
 				.then( newToken => {
 					expect( newToken.value ).to.equal( 'token-value' );
 				} );
@@ -195,7 +195,7 @@ describe( 'Token', () => {
 		it( 'should throw an error when the callback throws error', () => {
 			const token = new Token( () => Promise.reject( 'Custom error occurred' ), { initValue: 'initValue', autoRefresh: false } );
 
-			token._refreshToken()
+			token.refreshToken()
 				.catch( error => {
 					expect( error ).to.equal( 'Custom error occurred' );
 				} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Expose the `refreshToken` method.

---

### Additional information

We need to expose this method to be able to invoke it from the `ckeditor-cloud-services-collaboration` level. The method should be invoked during reconnection to get a new token (e.g. after awakening from the sleep mode - see: https://github.com/cksource/cs/issues/4689)
